### PR TITLE
Updated scroll events, resize events and updated loader class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 - Search algorithm has been redefined without impacting prior versions. Certain bugs are fixed.
 - Added `View More` to List dropdown at the end of the list as an alternative to call API when reaching the end of scroll.
 - Now the developers who consume this package can decide how they should trigger an API Call. Using `View More`, or triggering API Call when reaching end of scroll. Both can be configured as well. Refer below for more information.
-- Added the input properties - inspectAutoCompleteList, viewMoreText and optViewMoreOnlyForApiCall
+- Added the input properties - inspectAutoCompleteList, viewMoreText and optViewMoreOnlyForApiCall.
+- Renamed the internal class `loader`  to `autocomplete-plugin-loader` as `loader` class is too common name and may collide with other libraries.
+- Updated scroll event and resize event by using `Rerender2` to efficiently manage the event listeners.
 - Updated Readme file and stackblitz examples.
 - Upgrade to this package is recommended.
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "karma-jasmine": "~5.0.0",
     "karma-jasmine-html-reporter": "~1.7.0",
     "ng-packagr": "^14.0.0",
-    "typescript": "~4.7.2"
+    "typescript": "~4.7.2",
+    "@types/node": "^13.7.1"
   },
   "keywords": [
     "angular",

--- a/projects/autocomplete/src/lib/autocomplete.component.css
+++ b/projects/autocomplete/src/lib/autocomplete.component.css
@@ -57,7 +57,7 @@
     display: block;
 }
 
-.loader {
+.autocomplete-plugin-loader {
     width: 2rem;
     height: 2rem;
     border: 3px solid #D4D3D3;

--- a/projects/autocomplete/src/lib/autocomplete.component.html
+++ b/projects/autocomplete/src/lib/autocomplete.component.html
@@ -21,6 +21,7 @@ class="auto-complete-textfield-container">
   [ngStyle]="customStyle && customStyle.inputFieldContainerStyle ? customStyle.inputFieldContainerStyle : null"
   #fieldContainer>
   <input
+    #searchInput
     id="searchInput"
     [attr.role]="ariaRole"
     [(ngModel)]="searchValue"

--- a/projects/autocomplete/src/lib/autocomplete.component.html
+++ b/projects/autocomplete/src/lib/autocomplete.component.html
@@ -68,7 +68,7 @@ class="auto-complete-textfield-container">
             </li>
         </ng-container>
         </ng-container>
-        <li *ngIf="showLoadingSpinner && showDataLoader && !isCustomSpinner" class="auto-complete-list-spinner"><span class="loader"></span></li>
+        <li *ngIf="showLoadingSpinner && showDataLoader && !isCustomSpinner" class="auto-complete-list-spinner"><span class="autocomplete-plugin-loader"></span></li>
         <li *ngIf="showLoadingSpinner && showDataLoader && isCustomSpinner" class="auto-complete-list-spinner">
           <ng-content select="[customSpinner]"></ng-content>
         </li>


### PR DESCRIPTION
- Renamed the internal class `loader`  to `autocomplete-plugin-loader` as `loader` class is too common name and may collide with other libraries.
- Updated scroll event and resize event by using `Rerender2` to efficiently manage the event listeners.